### PR TITLE
adapters: cover the DNSControl and libdns conversion boundaries for every known record type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -288,7 +288,7 @@ require (
 	moul.io/http2curl v1.0.0 // indirect
 )
 
-replace github.com/DNSControl/dnscontrol/v4 => github.com/happyDomain/dnscontrol/v4 v4.46.100
+replace github.com/DNSControl/dnscontrol/v4 => github.com/happyDomain/dnscontrol/v4 v4.46.101
 
 // https://github.com/kataras/iris/issues/2587
 replace github.com/kataras/golog v0.1.15 => github.com/kataras/golog v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,8 @@ github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzq
 github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
-github.com/happyDomain/dnscontrol/v4 v4.46.100 h1:D2xfbh5hwFLn3PEsBVZA1g2VpQFYzeQ+B1/r3p6txbI=
-github.com/happyDomain/dnscontrol/v4 v4.46.100/go.mod h1:Cjfb2SZIslsezGtrqaW02c7VaNW49Y/f8zG6oA3wzc8=
+github.com/happyDomain/dnscontrol/v4 v4.46.101 h1:oHfqdQ5wy4urOrSCA0U2OGDCeW6VKQMUyuLl5TSW/no=
+github.com/happyDomain/dnscontrol/v4 v4.46.101/go.mod h1:Cjfb2SZIslsezGtrqaW02c7VaNW49Y/f8zG6oA3wzc8=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=

--- a/internal/adapters/dnscontrol-correction.go
+++ b/internal/adapters/dnscontrol-correction.go
@@ -116,6 +116,16 @@ func DNSControlDiffByRecord(oldrrs []happydns.Record, newrrs []happydns.Record, 
 	return ret, nbCorrections, nil
 }
 
+// canonicalDNSRR strips DNSControl's rtype wrapper (e.g. *rtype.DS) down to
+// the canonical miekg record (e.g. *dns.DS) it embeds, via the copy() method
+// promoted from that embedded record. The modern types (DS, RP, …) DNSControl
+// hands back from models.RecordConfig.ToRR() come wrapped that way, and the
+// FromStruct converting them back to a RecordConfig asserts on the canonical
+// type specifically, rejecting the wrapper.
+func canonicalDNSRR(rr dns.RR) dns.RR {
+	return dns.Copy(rr)
+}
+
 // DNSControlRRtoRC converts a slice of happyDomain records to DNSControl's RecordConfig format.
 // It handles conversion of custom record types (like happydns.TXT, happydns.SPF) to standard dns.RR
 // before converting to DNSControl format.
@@ -146,7 +156,7 @@ func DNSControlRRtoRC(rrs []happydns.Record, origin string) (dnscontrol.Records,
 
 		if _, ok := rtypecontrol.Func[typeName]; ok {
 			dcn := domaintags.MakeDomainNameVarieties(originNoTrailingDot)
-			rcPtr, e := rtypecontrol.NewRecordConfigFromStruct(rr.Header().Name, rr.Header().Ttl, typeName, rr, dcn)
+			rcPtr, e := rtypecontrol.NewRecordConfigFromStruct(rr.Header().Name, rr.Header().Ttl, typeName, canonicalDNSRR(rr.(dns.RR)), dcn)
 			if e != nil {
 				return nil, e
 			}

--- a/internal/adapters/dnscontrol-correction_test.go
+++ b/internal/adapters/dnscontrol-correction_test.go
@@ -353,3 +353,53 @@ func TestNewDNSControlDomainConfigRecords(t *testing.T) {
 		t.Errorf("record %q is missing", name)
 	}
 }
+
+// TestDNSControlRRtoRC_RtypeWrapper checks the modern types (DS, RP, …) survive
+// a round trip through DNSControl: models.RecordConfig.ToRR() hands back the
+// rtype wrapper (*rtype.DS) rather than the canonical *dns.DS, and the
+// FromStruct converting it back refuses anything but the canonical type.
+func TestDNSControlRRtoRC_RtypeWrapper(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rr   happydns.Record
+	}{
+		{
+			name: "DS",
+			rr: &dns.DS{
+				Hdr:        dns.RR_Header{Name: "sub.example.com.", Rrtype: dns.TypeDS, Class: dns.ClassINET, Ttl: 300},
+				KeyTag:     12345,
+				Algorithm:  13,
+				DigestType: 2,
+				Digest:     "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+			},
+		},
+		{
+			name: "RP",
+			rr: &dns.RP{
+				Hdr:  dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeRP, Class: dns.ClassINET, Ttl: 300},
+				Mbox: "admin.example.com.",
+				Txt:  "contact.example.com.",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rcs, err := adapter.DNSControlRRtoRC([]happydns.Record{tc.rr}, "example.com.")
+			if err != nil {
+				t.Fatalf("DNSControlRRtoRC: %v", err)
+			}
+
+			// The record DNSControl gives back is the rtype wrapper, not the
+			// canonical dns.RR we started from.
+			wrapped := rcs[0].ToRR()
+
+			rcs, err = adapter.DNSControlRRtoRC([]happydns.Record{wrapped}, "example.com.")
+			if err != nil {
+				t.Fatalf("DNSControlRRtoRC on the record returned by ToRR(): %v", err)
+			}
+
+			if got, expected := rcs[0].ToRR().String(), tc.rr.String(); got != expected {
+				t.Errorf("round trip altered the record: got %q, expected %q", got, expected)
+			}
+		})
+	}
+}

--- a/internal/adapters/dnscontrol-pseudotypes-supported.go
+++ b/internal/adapters/dnscontrol-pseudotypes-supported.go
@@ -175,9 +175,8 @@ func recordFromRecordConfig(rc *models.RecordConfig) (happydns.Record, error) {
 	// rc.ToRR() for modern types (DS, RP, …) returns the rtype wrapper (e.g.
 	// *rtype.DS) rather than the canonical *dns.DS. When these are later passed
 	// back through dnsrr.RRtoRC → DS.FromStruct, the type assertion on *dns.DS
-	// fails. dns.Copy invokes the promoted copy() method from the embedded
-	// *dns.DS, which returns the canonical type.
-	return dns.Copy(rr), nil
+	// fails.
+	return canonicalDNSRR(rr), nil
 }
 
 // checkPseudoTypesSupported refuses the pseudo-types the given provider does not

--- a/internal/adapters/dnscontrol-rrtypes_test.go
+++ b/internal/adapters/dnscontrol-rrtypes_test.go
@@ -1,0 +1,119 @@
+// This file is part of the happyDomain (R) project.
+// Copyright (c) 2020-2026 happyDomain
+// Authors: Pierre-Olivier Mercier, et al.
+//
+// This program is offered under a commercial and under the AGPL license.
+// For commercial licensing, contact us at <contact@happydomain.org>.
+//
+// For AGPL licensing:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package adapter
+
+import (
+	"testing"
+
+	"git.happydns.org/happyDomain/model"
+)
+
+// TestDNSControlRRtoRC_EveryType runs every record type through the conversion
+// to DNSControl and back, the way a zone published to a provider goes:
+// happyDomain record -> RecordConfig -> ToRR() -> RecordConfig. The second
+// conversion is the one prepare_changes does on the records read back, and the
+// one the rtype wrappers (DS, RP, …) used to fail.
+func TestDNSControlRRtoRC_EveryType(t *testing.T) {
+	for _, name := range sampleNames {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rr := parseSample(t, name)
+
+			rcs, err := DNSControlRRtoRC([]happydns.Record{rr}, rrTypesOrigin)
+			if err != nil {
+				t.Fatalf("DNSControlRRtoRC: %v", err)
+			}
+			if len(rcs) != 1 {
+				t.Fatalf("got %d RecordConfig, expected 1", len(rcs))
+			}
+
+			if got := rcs[0].Type; got != name {
+				t.Errorf("RecordConfig type is %q, expected %q", got, name)
+			}
+			if got := rcs[0].GetLabelFQDN(); got != "sample.example.com" {
+				t.Errorf("RecordConfig label is %q, expected \"sample.example.com\"", got)
+			}
+			if got := rcs[0].TTL; got != 300 {
+				t.Errorf("RecordConfig TTL is %d, expected 300", got)
+			}
+
+			back := rcs[0].ToRR()
+			if back == nil {
+				t.Fatalf("RecordConfig.ToRR() gave no record back")
+			}
+			if got, expected := back.String(), rr.String(); got != expected {
+				t.Fatalf("the conversion altered the record: got %q, expected %q", got, expected)
+			}
+
+			// The record DNSControl hands back must be convertible again: this
+			// is the round trip prepare_changes makes.
+			rcs, err = DNSControlRRtoRC([]happydns.Record{back}, rrTypesOrigin)
+			if err != nil {
+				t.Fatalf("DNSControlRRtoRC on the record given back by ToRR(): %v", err)
+			}
+			if got, expected := rcs[0].ToRR().String(), rr.String(); got != expected {
+				t.Errorf("the round trip altered the record: got %q, expected %q", got, expected)
+			}
+		})
+	}
+}
+
+// TestDNSControlDiffByRecord_EveryType checks the diff engine, which every
+// publication goes through, handles each type: a zone holding the record
+// against an empty one gives exactly one addition, and the record it carries is
+// the one we started from.
+func TestDNSControlDiffByRecord_EveryType(t *testing.T) {
+	for _, name := range sampleNames {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rr := parseSample(t, name)
+
+			corrections, nb, err := DNSControlDiffByRecord(nil, []happydns.Record{rr}, rrTypesOrigin)
+			if err != nil {
+				t.Fatalf("DNSControlDiffByRecord: %v", err)
+			}
+			if nb != 1 {
+				t.Fatalf("got %d corrections, expected 1", nb)
+			}
+			if corrections[0].Kind != happydns.CorrectionKindAddition {
+				t.Errorf("correction kind is %v, expected an addition", corrections[0].Kind)
+			}
+			if len(corrections[0].NewRecords) != 1 {
+				t.Fatalf("the correction carries %d records, expected 1", len(corrections[0].NewRecords))
+			}
+			if got, expected := corrections[0].NewRecords[0].String(), rr.String(); got != expected {
+				t.Errorf("the diff altered the record: got %q, expected %q", got, expected)
+			}
+
+			// The same zone on both sides gives nothing to do.
+			_, nb, err = DNSControlDiffByRecord([]happydns.Record{rr}, []happydns.Record{rr}, rrTypesOrigin)
+			if err != nil {
+				t.Fatalf("DNSControlDiffByRecord on two identical zones: %v", err)
+			}
+			if nb != 0 {
+				t.Errorf("got %d corrections between two identical zones, expected none", nb)
+			}
+		})
+	}
+}

--- a/internal/adapters/libdns-providers.go
+++ b/internal/adapters/libdns-providers.go
@@ -188,24 +188,31 @@ func (p *LibdnsAdapterNSProvider) GetZoneCorrections(domain string, wantedRecord
 		return nil, 0, fmt.Errorf("unable to get current zone records: %w", err)
 	}
 
-	currentRecords, err := libdnsRecordsToHappyDNS(currentLibdnsRecs, zone)
-	if err != nil {
-		return nil, 0, fmt.Errorf("unable to convert current zone records: %w", err)
+	// Convert the provider records once, keeping both the happydns view (for
+	// the diff engine) and a lookup from record key → original libdns
+	// records, the concrete type the provider handed us, carrying whatever
+	// identifier it needs to delete the record later.
+	currentRecords := make([]happydns.Record, 0, len(currentLibdnsRecs))
+	libdnsRecordsByKey := make(map[string][]libdns.Record, len(currentLibdnsRecs))
+	for _, rec := range currentLibdnsRecs {
+		hdr, err := libdnsToHappyDNSRecord(rec, zone)
+		if err != nil {
+			return nil, 0, fmt.Errorf("converting libdns record %v: %w", rec.RR(), err)
+		}
+
+		key := libdnsRecordKey(hdr, zone)
+		libdnsRecordsByKey[key] = append(libdnsRecordsByKey[key], rec)
+
+		if IsPseudoTypeRecord(hdr) {
+			continue
+		}
+		currentRecords = append(currentRecords, hdr)
 	}
 
 	// Step 2: Compute diff using existing DNSControl diff engine.
 	diffs, nbDiffs, err := DNSControlDiffByRecord(currentRecords, wantedRecords, domain)
 	if err != nil {
 		return nil, nbDiffs, fmt.Errorf("unable to compute zone diff: %w", err)
-	}
-
-	// Build a lookup from happydns Record string → original libdns records (with ProviderData).
-	// This ensures delete operations use the provider's record IDs.
-	libdnsRecordsByKey := make(map[string][]libdns.Record)
-	for _, rec := range currentLibdnsRecs {
-		rr := rec.RR()
-		key := fmt.Sprintf("%s\t%s\t%s", rr.Name, rr.Type, rr.Data)
-		libdnsRecordsByKey[key] = append(libdnsRecordsByKey[key], rec)
 	}
 
 	// Step 3: Create corrections with executable F closures.
@@ -303,8 +310,7 @@ func (p *LibdnsAdapterNSProvider) resolveOriginalRecords(
 ) []libdns.Record {
 	result := make([]libdns.Record, 0, len(records))
 	for _, rec := range records {
-		rr := happyDNSRecordToLibdnsRR(rec, zone)
-		key := fmt.Sprintf("%s\t%s\t%s", rr.Name, rr.Type, rr.Data)
+		key := libdnsRecordKey(rec, zone)
 
 		if originals, ok := libdnsRecordsByKey[key]; ok && len(originals) > 0 {
 			// Use the original record and consume it from the map.
@@ -312,7 +318,7 @@ func (p *LibdnsAdapterNSProvider) resolveOriginalRecords(
 			libdnsRecordsByKey[key] = originals[1:]
 		} else {
 			// Fallback: use the converted RR (without ProviderData).
-			result = append(result, rr)
+			result = append(result, happyDNSRecordToLibdnsRR(rec, zone))
 		}
 	}
 	return result

--- a/internal/adapters/libdns-providers_test.go
+++ b/internal/adapters/libdns-providers_test.go
@@ -398,3 +398,74 @@ func TestLibdnsAdapterSkipsPseudoTypesOnImport(t *testing.T) {
 		t.Errorf("got %d corrections, want none: %v", nb, corrections)
 	}
 }
+
+// providerRecord stands for the concrete type a real libdns provider hands
+// back, carrying the identifier it needs to delete the record afterwards.
+type providerRecord struct {
+	rr libdns.RR
+	id string
+}
+
+func (p providerRecord) RR() libdns.RR { return p.rr }
+
+// TestLibdnsAdapterDeleteKeepsProviderRecord checks a deletion is asked with
+// the very record the provider gave us, and not with the plain libdns.RR the
+// conversion rebuilds: providers identify the record to delete by the data they
+// attached to it, which only their own type carries.
+//
+// The records below are all spelled the way a provider may spell them, rather
+// than the way miekg/dns writes them back.
+func TestLibdnsAdapterDeleteKeepsProviderRecord(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		rrType string
+		data   string
+	}{
+		{"absolute target", "MX", "10 mail.example.com."},
+		{"relative target", "MX", "10 mail"},
+		{"relative CNAME target", "CNAME", "target"},
+		{"quoted TXT", "TXT", `"hello world"`},
+		{"unquoted TXT", "TXT", "hello world"},
+		{"TXT in several strings", "TXT", `"part one " "part two"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			original := providerRecord{
+				rr: libdns.RR{Name: "sub", TTL: 300 * time.Second, Type: tc.rrType, Data: tc.data},
+				id: "provider-id-42",
+			}
+
+			mock := &mockLibdnsProvider{records: []libdns.Record{original}}
+			adapter, err := NewLibdnsProviderAdapter(&mockLibdnsConfig{provider: mock})
+			if err != nil {
+				t.Fatalf("NewLibdnsProviderAdapter: %v", err)
+			}
+
+			// An empty desired zone: the record has to be deleted.
+			corrections, nb, err := adapter.GetZoneCorrections("example.com", nil)
+			if err != nil {
+				t.Fatalf("GetZoneCorrections: %v", err)
+			}
+			if nb != 1 {
+				t.Fatalf("got %d corrections, expected the deletion alone", nb)
+			}
+			if corrections[0].Kind != happydns.CorrectionKindDeletion {
+				t.Fatalf("correction kind is %v, expected a deletion", corrections[0].Kind)
+			}
+
+			if err := corrections[0].F(); err != nil {
+				t.Fatalf("applying the correction: %v", err)
+			}
+
+			if len(mock.deleted) != 1 {
+				t.Fatalf("%d records deleted, expected 1", len(mock.deleted))
+			}
+			deleted, ok := mock.deleted[0].(providerRecord)
+			if !ok {
+				t.Fatalf("the deletion was asked with a %T rebuilt from the diff (%v), not with the record the provider gave us", mock.deleted[0], mock.deleted[0].RR())
+			}
+			if deleted.id != original.id {
+				t.Errorf("the deleted record carries the id %q, expected %q", deleted.id, original.id)
+			}
+		})
+	}
+}

--- a/internal/adapters/libdns-records.go
+++ b/internal/adapters/libdns-records.go
@@ -131,6 +131,34 @@ func happyDNSRecordToLibdnsRR(record happydns.Record, zone string) libdns.RR {
 	}
 }
 
+// libdnsRecordKey returns the string identifying a record among the ones of a
+// zone, for matching a record read from a provider with the same record coming
+// back from the diff engine.
+//
+// It cannot be built on the libdns rdata: a provider spells it the way it
+// likes, and the two sides do not go through the same conversions. A provider
+// answering "10 mail" for an MX gives an absolute target once imported, and the
+// diff engine hands the record back in that form; a TXT is raw text on one side
+// (happydns.TXT) and quoted on the other (dns.TXT, rebuilt by DNSControl).
+// Keying on either spelling makes the lookup miss, and a deletion then loses the
+// concrete record the provider gave us, hence the identifier it needs to carry
+// out the deletion.
+//
+// So the key is taken from the canonical miekg form of the record, which both
+// sides reach: the zone file rdata, with names made absolute and character
+// strings quoted, whatever way the record arrived.
+func libdnsRecordKey(record happydns.Record, zone string) string {
+	rr := record
+	if cr, ok := record.(happydns.ConvertibleRecord); ok {
+		rr = cr.ToRR()
+	}
+
+	typStr := dns.TypeToString[rr.Header().Rrtype]
+	name := libdns.RelativeName(rr.Header().Name, zone)
+
+	return fmt.Sprintf("%s\t%s\t%s", name, typStr, extractRdata(rr.String(), typStr))
+}
+
 // decodeTXTData decodes TXT record data that may be in RFC1035 presentation
 // format (quoted, with escaping) or raw text. Some libdns providers (e.g.
 // PowerDNS) return quoted data like `"value"`, while others (e.g. libdns.TXT)
@@ -193,13 +221,4 @@ func libdnsRecordsToHappyDNS(recs []libdns.Record, zone string) ([]happydns.Reco
 		result = append(result, hdr)
 	}
 	return result, nil
-}
-
-// happyDNSRecordsToLibdns converts a slice of happydns Records to libdns RR values.
-func happyDNSRecordsToLibdns(rrs []happydns.Record, zone string) []libdns.RR {
-	result := make([]libdns.RR, len(rrs))
-	for i, rr := range rrs {
-		result[i] = happyDNSRecordToLibdnsRR(rr, zone)
-	}
-	return result
 }

--- a/internal/adapters/libdns-rrtypes_test.go
+++ b/internal/adapters/libdns-rrtypes_test.go
@@ -1,0 +1,203 @@
+// This file is part of the happyDomain (R) project.
+// Copyright (c) 2020-2026 happyDomain
+// Authors: Pierre-Olivier Mercier, et al.
+//
+// This program is offered under a commercial and under the AGPL license.
+// For commercial licensing, contact us at <contact@happydomain.org>.
+//
+// For AGPL licensing:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package adapter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/libdns/libdns"
+
+	"git.happydns.org/happyDomain/model"
+)
+
+// sampleLibdnsRR builds the libdns.RR a provider would hand back for the given
+// type and rdata.
+func sampleLibdnsRR(rrType, data string) libdns.RR {
+	return libdns.RR{Name: "sample", TTL: 300 * time.Second, Type: rrType, Data: data}
+}
+
+// TestLibdnsRoundTrip_EveryType runs every record type through the libdns
+// conversion and back.
+//
+// Unlike the DNSControl one, this boundary is made of text: the rdata leaves as
+// the tail of the miekg zone file line (extractRdata) and comes back parsed
+// from a line rebuilt around it. A type whose presentation format the parser
+// reads differently from the way it writes it does not survive the trip.
+func TestLibdnsRoundTrip_EveryType(t *testing.T) {
+	for _, name := range sampleNames {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rr := parseSample(t, name)
+
+			out := happyDNSRecordToLibdnsRR(rr, rrTypesOrigin)
+
+			if got := out.Name; got != "sample" {
+				t.Errorf("libdns name is %q, expected \"sample\"", got)
+			}
+			if got := out.Type; got != name {
+				t.Errorf("libdns type is %q, expected %q", got, name)
+			}
+			if got, expected := out.TTL, 300*time.Second; got != expected {
+				t.Errorf("libdns TTL is %v, expected %v", got, expected)
+			}
+			if out.Data == "" {
+				t.Fatalf("libdns rdata is empty, the record was %q", rr.String())
+			}
+
+			back, err := libdnsToHappyDNSRecord(out, rrTypesOrigin)
+			if err != nil {
+				t.Fatalf("converting %q back: %v", out.Data, err)
+			}
+
+			if got, expected := back.String(), rr.String(); got != expected {
+				t.Errorf("the round trip altered the record: got %q, expected %q", got, expected)
+			}
+		})
+	}
+}
+
+// TestLibdnsImport_EveryType reads a zone holding one record of each type from
+// a provider, and asks for the corrections towards that very same zone. A
+// record the import spells differently from the way the diff engine hands it
+// back shows up as a correction: the provider would then be asked, at every
+// publication, to apply a change that changes nothing.
+func TestLibdnsImport_EveryType(t *testing.T) {
+	for _, name := range sampleNames {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rr := parseSample(t, name)
+
+			mock := &mockLibdnsProvider{records: []libdns.Record{
+				sampleLibdnsRR(name, rrSamples[name]),
+			}}
+
+			adapter, err := NewLibdnsProviderAdapter(&mockLibdnsConfig{provider: mock})
+			if err != nil {
+				t.Fatalf("NewLibdnsProviderAdapter: %v", err)
+			}
+
+			imported, err := adapter.GetZoneRecords("example.com")
+			if err != nil {
+				t.Fatalf("GetZoneRecords: %v", err)
+			}
+			if len(imported) != 1 {
+				t.Fatalf("imported %d records, expected 1", len(imported))
+			}
+			if got, expected := imported[0].String(), rr.String(); got != expected {
+				t.Errorf("the import altered the record: got %q, expected %q", got, expected)
+			}
+
+			_, nb, err := adapter.GetZoneCorrections("example.com", []happydns.Record{rr})
+			if err != nil {
+				t.Fatalf("GetZoneCorrections: %v", err)
+			}
+			if nb != 0 {
+				t.Errorf("got %d corrections against the zone the provider already holds, expected none", nb)
+			}
+		})
+	}
+}
+
+// TestLibdnsRecordKey_EveryType checks the key a record read from a provider
+// gets is the one it gets again once the diff engine has handed it back. Those
+// two are what resolveOriginalRecords matches to keep the concrete record of
+// the provider, and its identifier, on a deletion.
+func TestLibdnsRecordKey_EveryType(t *testing.T) {
+	for _, name := range sampleNames {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			rr := parseSample(t, name)
+
+			// As read from a provider.
+			imported, err := libdnsToHappyDNSRecord(
+				sampleLibdnsRR(name, rrSamples[name]),
+				rrTypesOrigin,
+			)
+			if err != nil {
+				t.Fatalf("importing: %v", err)
+			}
+
+			// As handed back by the diff engine, which rebuilds the record from
+			// the RecordConfig it made of it.
+			rcs, err := DNSControlRRtoRC([]happydns.Record{rr}, rrTypesOrigin)
+			if err != nil {
+				t.Fatalf("DNSControlRRtoRC: %v", err)
+			}
+			fromDiff, err := recordFromRecordConfig(rcs[0])
+			if err != nil {
+				t.Fatalf("recordFromRecordConfig: %v", err)
+			}
+
+			if got, expected := libdnsRecordKey(fromDiff, rrTypesOrigin), libdnsRecordKey(imported, rrTypesOrigin); got != expected {
+				t.Errorf("the record read from the provider and the one given back by the diff have different keys:\n  provider %q\n      diff %q", expected, got)
+			}
+		})
+	}
+}
+
+// TestLibdnsRecordKey_ProviderSpellings covers the spellings a provider is free
+// to use for an rdata miekg/dns writes otherwise: the key must not depend on
+// them. This is what a deletion matching the record of the provider rests on.
+func TestLibdnsRecordKey_ProviderSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		rrType   string
+		data     string
+		expected string // the same record, spelled the way miekg/dns writes it
+	}{
+		{"relative MX target", "MX", "10 mail", "10 mail.example.com."},
+		{"relative CNAME target", "CNAME", "target", "target.example.com."},
+		{"relative SRV target", "SRV", "10 20 5060 sip", "10 20 5060 sip.example.com."},
+		{"unquoted TXT", "TXT", "hello world", `"hello world"`},
+		{"TXT in several strings", "TXT", `"part one " "part two"`, `"part one part two"`},
+		{"unpadded IPv6", "AAAA", "2001:0db8:0000::1", "2001:db8::1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			asProviderSpellsIt, err := libdnsToHappyDNSRecord(
+				sampleLibdnsRR(tc.rrType, tc.data),
+				rrTypesOrigin,
+			)
+			if err != nil {
+				t.Fatalf("importing %q: %v", tc.data, err)
+			}
+
+			asMiekgWritesIt, err := libdnsToHappyDNSRecord(
+				sampleLibdnsRR(tc.rrType, tc.expected),
+				rrTypesOrigin,
+			)
+			if err != nil {
+				t.Fatalf("importing %q: %v", tc.expected, err)
+			}
+
+			got := libdnsRecordKey(asProviderSpellsIt, rrTypesOrigin)
+			if expected := libdnsRecordKey(asMiekgWritesIt, rrTypesOrigin); got != expected {
+				t.Errorf("%q and %q are the same record but have different keys:\n  got %q\n  expected %q", tc.data, tc.expected, got, expected)
+			}
+		})
+	}
+}

--- a/internal/adapters/rrtypes-samples_test.go
+++ b/internal/adapters/rrtypes-samples_test.go
@@ -1,0 +1,183 @@
+// This file is part of the happyDomain (R) project.
+// Copyright (c) 2020-2026 happyDomain
+// Authors: Pierre-Olivier Mercier, et al.
+//
+// This program is offered under a commercial and under the AGPL license.
+// For commercial licensing, contact us at <contact@happydomain.org>.
+//
+// For AGPL licensing:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package adapter
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/miekg/dns"
+
+	"git.happydns.org/happyDomain/model"
+)
+
+const rrTypesOrigin = "example.com."
+
+// rrSamples holds one zone file line per record type miekg/dns is able to
+// build, the rdata apart: the label and the TTL are added by the test.
+//
+// The adapters run their conversions over this table, see
+// dnscontrol-rrtypes_test.go.
+var rrSamples = map[string]string{
+	"A":          "1.2.3.4",
+	"AAAA":       "2001:db8::1",
+	"AFSDB":      "1 afs.example.com.",
+	"AMTRELAY":   "10 0 1 203.0.113.1",
+	"APL":        "1:192.0.2.0/24 !1:192.0.2.128/25",
+	"AVC":        `"app-name=example"`,
+	"CAA":        `0 issue "ca.example.net"`,
+	"CDNSKEY":    "257 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"CDS":        "12345 13 2 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+	"CERT":       "1 12345 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"CNAME":      "target.example.com.",
+	"CSYNC":      "66 3 A NS AAAA",
+	"DHCID":      "AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=",
+	"DLV":        "12345 13 2 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+	"DNAME":      "target.example.com.",
+	"DNSKEY":     "256 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"DS":         "12345 13 2 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+	"EID":        "E32C6F78163167F9",
+	"EUI48":      "00-00-5e-00-53-2a",
+	"EUI64":      "00-00-5e-ef-10-00-00-2a",
+	"GID":        "1000",
+	"GPOS":       "-32.6882 116.8652 10.0",
+	"HINFO":      `"amd64" "linux"`,
+	"HIP":        "2 200100107B1A74DF365639CC39F1D578 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ== rvs.example.com.",
+	"HTTPS":      `1 . alpn="h2,h3" ipv4hint="192.0.2.1"`,
+	"IPSECKEY":   "10 1 2 192.0.2.38 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"ISDN":       `"150862028003217" "004"`,
+	"KEY":        "256 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"KX":         "10 kx.example.com.",
+	"L32":        "10 10.1.2.0",
+	"L64":        "10 0014:4fff:ff20:ee64",
+	"LOC":        "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000.00m 10.00m",
+	"LP":         "10 l64-subnet.example.com.",
+	"MB":         "mailbox.example.com.",
+	"MD":         "mailagent.example.com.",
+	"MF":         "mailagent.example.com.",
+	"MG":         "member.example.com.",
+	"MINFO":      "rmail.example.com. email.example.com.",
+	"MR":         "newname.example.com.",
+	"MX":         "10 mail.example.com.",
+	"NAPTR":      `100 50 "s" "z3950+I2L+I2C" "" _z3950._tcp.example.com.`,
+	"NID":        "10 0014:4fff:ff20:ee64",
+	"NIMLOC":     "E32C6F78163167F9",
+	"NINFO":      `"this is a zone status"`,
+	"NS":         "ns1.example.com.",
+	"NSAP-PTR":   "nsap.example.com.",
+	"NSEC":       "next.example.com. A MX RRSIG NSEC",
+	"NSEC3":      "1 1 12 aabbccdd 2vptu5timamqttgl4luu9kg21e0aor3s A RRSIG",
+	"NSEC3PARAM": "1 0 12 aabbccdd",
+	"NXT":        "next.example.com. A MX",
+	"OPENPGPKEY": "mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"PTR":        "host.example.com.",
+	"PX":         "10 net2.example.com. prmd-net2.admd-p400.c-it.",
+	"RESINFO":    `"qnamemin" "exterr=15,16,17"`,
+	"RKEY":       "0 0 0 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"RP":         "admin.example.com. contact.example.com.",
+	"RRSIG":      "A 13 2 3600 20260101000000 20251201000000 12345 example.com. mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"RT":         "10 relay.example.com.",
+	"SIG":        "A 13 2 3600 20260101000000 20251201000000 12345 example.com. mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==",
+	"SMIMEA":     "3 1 1 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+	"SOA":        "ns1.example.com. hostmaster.example.com. 2026010101 7200 3600 1209600 3600",
+	"SPF":        `"v=spf1 -all"`,
+	"SRV":        "10 20 8080 target.example.com.",
+	"SSHFP":      "1 2 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+	"SVCB":       `1 svc.example.com. alpn="h2" port="8080"`,
+	"TA":         "12345 13 2 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+	"TALINK":     "prev.example.com. next.example.com.",
+	"TLSA":       "3 1 1 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+	"TXT":        `"a piece of text"`,
+	"UID":        "1000",
+	"UINFO":      `"some user info"`,
+	"URI":        `10 1 "https://example.com/"`,
+	"X25":        "311061700956",
+	"ZONEMD":     "2026010101 1 1 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+}
+
+// rrNotZoneTypes are the types miekg/dns builds records of, but which never
+// appear in a zone: the meta-types carried in a message alone, and the ones
+// with no presentation format.
+var rrNotZoneTypes = map[string]string{
+	"ANY":    "QTYPE, asked in a query, never held in a zone",
+	"NULL":   "RFC 1035 says it cannot appear in a zone file",
+	"NXNAME": "pseudo-type of the compact denial of existence, only in a response",
+	"OPT":    "EDNS0 meta-record, carried in the additional section",
+	"TKEY":   "meta-record of the key exchange, never held in a zone",
+	"TSIG":   "meta-record of the message signature, never held in a zone",
+}
+
+// sampleNames holds the types of the sample table in a stable order.
+var sampleNames = func() []string {
+	names := make([]string, 0, len(rrSamples))
+	for name := range rrSamples {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
+}()
+
+// TestRRSamplesCoverEveryType makes sure the sample table above keeps up with
+// miekg/dns: a type it learns to build is either given a sample, or explicitly
+// left out.
+func TestRRSamplesCoverEveryType(t *testing.T) {
+	excluded := map[string]bool{}
+	for name := range rrNotZoneTypes {
+		excluded[name] = true
+	}
+	// The DNSControl pseudo-types happyDomain registers as private use types
+	// in miekg/dns: dnscontrol-pseudotypes_test.go covers them, they have no
+	// rdata a zone file could hold in the general case.
+	for name := range supportedPseudoTypes {
+		excluded[name] = true
+	}
+
+	var missing []string
+	for rrtype := range dns.TypeToRR {
+		name := dns.TypeToString[rrtype]
+		if _, ok := rrSamples[name]; !ok && !excluded[name] {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+
+	for _, name := range missing {
+		t.Errorf("type %s has no sample in rrSamples: add one, or list it in rrNotZoneTypes", name)
+	}
+
+	// The other way around: a sample naming a type miekg/dns cannot build is a
+	// typo.
+	for name := range rrSamples {
+		rrtype, known := dns.StringToType[name]
+		if !known || dns.TypeToRR[rrtype] == nil {
+			t.Errorf("rrSamples holds %s, which miekg/dns is unable to build", name)
+		}
+	}
+}
+
+// parseSample builds the record of the given type from its sample rdata.
+func parseSample(t *testing.T, name string) happydns.Record {
+	t.Helper()
+
+	return mustRR(t, "sample."+rrTypesOrigin+" 300 IN "+name+" "+rrSamples[name])
+}

--- a/internal/adapters/rrtypes-samples_test.go
+++ b/internal/adapters/rrtypes-samples_test.go
@@ -35,8 +35,8 @@ const rrTypesOrigin = "example.com."
 // rrSamples holds one zone file line per record type miekg/dns is able to
 // build, the rdata apart: the label and the TTL are added by the test.
 //
-// The adapters run their conversions over this table, see
-// dnscontrol-rrtypes_test.go.
+// Both adapters run their conversions over this table, see
+// dnscontrol-rrtypes_test.go and libdns-rrtypes_test.go.
 var rrSamples = map[string]string{
 	"A":          "1.2.3.4",
 	"AAAA":       "2001:db8::1",


### PR DESCRIPTION
The adapter layer converts records between happyDomain's `RecordConfig` and the two provider boundaries it talks to (DNSControl's `RecordConfig` and libdns' text-based records), but that conversion was only exercised for a handful of record types.

Two real bugs were already hiding there:

- DNSControl's "modern type" records ([DS](https://github.com/DNSControl/dnscontrol/pull/3996), [RP](https://github.com/DNSControl/dnscontrol/pull/3886), …) are now wrapped in a struct embedding the miekg record, and the reverse conversion type-asserted on the bare miekg type, so a round trip failed in `prepare_changes` with `fields is not *dns.DS, got *rtype.DS`.
- The libdns deletion path indexed provider-read records by their rdata as spelled by the provider, but looked them up by the rdata rebuilt from the diff engine. Nothing keeps those two spellings equal (an MX target becomes absolute, a TXT gets quoted and its strings joined), so the lookup missed and a provider identifying records by an id of its own deleted nothing.

Both were found and fixed by hand for one record type at a time; nothing checked whether the rest of the ~60 record types miekg/dns knows about survive the trip at all.

## Solution

- Normalize modern-type records through `dns.Copy` before the `RecordConfig` conversion, so a wrapper reaching that choke point is handled regardless of which path produced it ([`ff7ade43`](https://github.com/happyDomain/happydomain/commit/ff7ade43e2ac58cacc619716ba8a8ee9464db3fd)).
- Add a sample table covering every record type miekg/dns can build, and run it through both the DNSControl `RecordConfig` conversion and the diff engine. The table is held to the miekg/dns type list, so **a type added by a future release fails** until it gets a sample or an explicit exclusion.
  This turned up AVC and NINFO panicking rather than converting; [fixed in our DNSControl fork](https://github.com/happyDomain/dnscontrol/commit/8b66465d569b0bdbf58db2a5efde70789bc99f40) ([`c082a6ae`](https://github.com/happyDomain/happydomain/commit/c082a6ae2fb6852218fa1d105dd1c6d12479da73)).
- Key the libdns deletion lookup on the canonical miekg form on both sides (index and lookup), rather than on the provider's own spelling, so it matches whatever way the record arrived ([`a2782a5e`](https://github.com/happyDomain/happydomain/commit/a2782a5eb3c376d2aa21b5e4139c324c90705012)).
- Run the same sample table through the libdns boundary too, in the three ways a record travels through it: conversion to a libdns record and back, import of a zone followed by generating corrections towards that same zone (which must be empty), and the key used to match a deletion ([`7c077843`](https://github.com/happyDomain/happydomain/commit/7c07784371a0773863db5af7656679f8e41ab922)).